### PR TITLE
Change template config

### DIFF
--- a/src/Config/RootConfig.php
+++ b/src/Config/RootConfig.php
@@ -10,15 +10,13 @@ class RootConfig extends IndexConfig
     protected $renderingProcess;
     protected $tocProcess;
     protected $headingsProcess;
-    protected $templates = array();
-    protected $templateName;
+    protected $template;
 
     protected function init()
     {
         parent::init();
         $this->initTarget();
-        $this->initTemplates();
-        $this->initTemplateName();
+        $this->initTemplate();
         $this->initConversionProcess();
         $this->initHeadingsProcess();
         $this->initTocProcess();
@@ -36,18 +34,11 @@ class RootConfig extends IndexConfig
         $this->target = $target . DIRECTORY_SEPARATOR;
     }
 
-    protected function initTemplates()
+    protected function initTemplate()
     {
-        $this->templates = empty($this->json->templates)
-            ? array()
-            : (array) $this->json->templates;
-    }
-
-    protected function initTemplateName()
-    {
-        $this->templateName = empty($this->json->templateName)
+        $this->template = empty($this->json->template)
             ? null
-            : $this->json->templateName;
+            : $this->json->template;
     }
 
     protected function initConversionProcess()
@@ -103,14 +94,9 @@ class RootConfig extends IndexConfig
         return $this->target;
     }
 
-    public function getTemplates()
+    public function getTemplate()
     {
-        return $this->templates;
-    }
-
-    public function getTemplateName()
-    {
-        return $this->templateName;
+        return $this->template;
     }
 
     public function get($key, $alt = null)

--- a/src/Process/Rendering/RenderingProcessBuilder.php
+++ b/src/Process/Rendering/RenderingProcessBuilder.php
@@ -28,55 +28,21 @@ class RenderingProcessBuilder implements ProcessBuilderInterface
         $viewFactory = new ViewFactory();
         $view = $viewFactory->newInstance($helpers);
 
-        $this->registerTemplates($view, $config);
-        $this->setTemplateName($view, $config);
+        $this->setTemplate($view, $config);
 
         return $view;
     }
 
-    protected function registerTemplates(View $view, RootConfig $config)
+    protected function setTemplate(View $view, RootConfig $config)
     {
+        $template = $config->getTemplate();
+        if (! $template) {
+            $template = dirname(dirname(dirname(__DIR__))) . '/templates/main.php';
+        }
+
         $registry = $view->getViewRegistry();
+        $registry->set('__BOOKDOWN__', $template);
 
-        // defaults
-        $templates = $this->getTemplates();
-        foreach ($templates as $name => $template) {
-            $registry->set($name, $template);
-        }
-
-        // overrides
-        $dir = $config->getDir();
-        $templates = (array) $config->getTemplates();
-        foreach ($templates as $name => $template) {
-            $registry->set($name, "{$dir}/{$template}");
-        }
-    }
-
-    protected function setTemplateName(View $view, RootConfig $config)
-    {
-        $templateName = $config->getTemplateName();
-        if (! $templateName) {
-            $templateName = $this->getTemplateName();
-        }
-        $view->setView($templateName);
-    }
-
-    protected function getTemplates()
-    {
-        $dir = dirname(dirname(dirname(__DIR__))) . '/templates';
-        return array(
-            "main" => "{$dir}/main.php",
-            "head" => "{$dir}/head.php",
-            "body" => "{$dir}/body.php",
-            "core" => "{$dir}/core.php",
-            "navheader" => "{$dir}/navheader.php",
-            "navfooter" => "{$dir}/navfooter.php",
-            "toc" => "{$dir}/toc.php",
-        );
-    }
-
-    protected function getTemplateName()
-    {
-        return 'main';
+        $view->setView('__BOOKDOWN__');
     }
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -1,3 +1,12 @@
+<?php
+$views = $this->getViewRegistry();
+$views->set('head', __DIR__ . '/head.php');
+$views->set('body', __DIR__ . '/body.php');
+$views->set('core', __DIR__ . '/core.php');
+$views->set('navheader', __DIR__ . '/navheader.php');
+$views->set('navfooter', __DIR__ . '/navfooter.php');
+$views->set('toc', __DIR__ . '/toc.php');
+?>
 <html>
 <?php echo $this->render('head'); ?>
 <?php echo $this->render('body'); ?>

--- a/tests/Config/RootConfigTest.php
+++ b/tests/Config/RootConfigTest.php
@@ -13,10 +13,7 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
             "baz": "http://example.com/baz.md"
         },
         "target": "my/target",
-        "templates": {
-            "master": "master.php"
-        },
-        "templateName": "master",
+        "template": "/path/to/templates/master.php",
         "conversionProcess": "My\\\\Conversion\\\\Builder",
         "headingsProcess": "My\\\\Headings\\\\Builder",
         "tocProcess": "My\\\\Toc\\\\Builder",
@@ -54,11 +51,7 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertBasics($config);
 
         $this->assertSame('/path/to/my/target/', $config->getTarget());
-        $expect = array(
-            'master' => 'master.php'
-        );
-        $this->assertSame($expect, $config->getTemplates());
-        $this->assertSame('master', $config->getTemplateName());
+        $this->assertSame('/path/to/templates/master.php', $config->getTemplate());
         $this->assertSame('My\\Conversion\\Builder', $config->getConversionProcess());
         $this->assertSame('My\\Headings\\Builder', $config->getHeadingsProcess());
         $this->assertSame('My\\Toc\\Builder', $config->getTocProcess());
@@ -86,8 +79,7 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertBasics($config);
 
         $this->assertSame('/path/to/_site/', $config->getTarget());
-        $this->assertSame(array(), $config->getTemplates());
-        $this->assertSame(null, $config->getTemplateName());
+        $this->assertSame(null, $config->getTemplate());
         $this->assertSame(
             'Bookdown\Bookdown\Process\Conversion\ConversionProcessBuilder',
             $config->getConversionProcess()
@@ -114,5 +106,4 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->newRootConfig('/path/to/bookdown.json', $this->missingTargetJson);
     }
-
 }


### PR DESCRIPTION
Removes "templateName" and "templates" from RootConfig in favor of just "template", the path to the main/master template.

The main/master template name is now forced to `__BOOKDOWN__`, and defaults to "templates/main.php".

The main.php template now registers its own sub-templates, to consolidate template control in a single location.
