### PR TITLE
BC break from develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Bookdown has 100% test coverage. To run the tests, install [PHPUnit](http://phpu
 
     - `"afterToc"`: indicates a Markdown file to place on the index page after the TOC
 
+    - `"subtitle"`: indicates a subtitle on an index page
+
 - navigational elements
 
     - sidebar of siblings at the current level

--- a/src/Config/IndexConfig.php
+++ b/src/Config/IndexConfig.php
@@ -84,7 +84,7 @@ class IndexConfig
 
         $name = basename($origin);
         if (substr($name, -13) == 'bookdown.json') {
-            $name = basename(dirname($name));
+            $name = basename(dirname($origin));
             return $this->addContent($name, $origin);
         }
 
@@ -99,11 +99,11 @@ class IndexConfig
     protected function addContent($name, $origin)
     {
         if ($name == 'index') {
-            throw new Exception("Disallowed 'index' content name in {$this->file}.");
+            throw new Exception("Disallowed 'index' content name in '{$this->file}'.");
         }
 
         if (isset($this->content[$name])) {
-            throw new Exception("Content name '{$name}' already set in {$this->file}.");
+            throw new Exception("Content name '{$name}' already set in '{$this->file}'.");
         }
 
         $this->content[$name] = $this->fixPath($origin);

--- a/src/Config/IndexConfig.php
+++ b/src/Config/IndexConfig.php
@@ -82,8 +82,11 @@ class IndexConfig
             return $this->addContent($name, $origin);
         }
 
-        $name = basename($origin);
-        if (substr($name, -13) == 'bookdown.json') {
+        if (! is_string($origin)) {
+            throw new Exception("Content origin must be object or string in '{$this->file}'.");
+        }
+
+        if (substr($origin, -13) == 'bookdown.json') {
             $name = basename(dirname($origin));
             return $this->addContent($name, $origin);
         }

--- a/src/Config/IndexConfig.php
+++ b/src/Config/IndexConfig.php
@@ -56,21 +56,57 @@ class IndexConfig
 
     protected function initContent()
     {
-        $this->content = empty($this->json->content)
+        $content = empty($this->json->content)
             ? array()
-            : (array) $this->json->content;
+            : $this->json->content;
 
-        if (! $this->content) {
+        if (! $content) {
             throw new Exception("No content listed in '{$this->file}'.");
         }
 
-        if (isset($this->content['index'])) {
-            throw new Exception("Disallowed 'index' content in {$this->file}.");
+        if (! is_array($content)) {
+            throw new Exception("Content must be an array in '{$this->file}'.");
         }
 
-        foreach ($this->content as $name => $origin) {
-            $this->content[$name] = $this->fixPath($origin);
+        foreach ($content as $key => $val) {
+            $this->initContentItem($val);
         }
+    }
+
+    protected function initContentItem($origin)
+    {
+        if (is_object($origin)) {
+            $spec = (array) $origin;
+            $name = key($spec);
+            $origin = current($spec);
+            return $this->addContent($name, $origin);
+        }
+
+        $name = basename($origin);
+        if (substr($name, -13) == 'bookdown.json') {
+            $name = basename(dirname($name));
+            return $this->addContent($name, $origin);
+        }
+
+        $name = basename($origin);
+        $pos = strrpos($name, '.');
+        if ($pos !== false) {
+            $name = substr($name, 0, $pos);
+        }
+        return $this->addContent($name, $origin);
+    }
+
+    protected function addContent($name, $origin)
+    {
+        if ($name == 'index') {
+            throw new Exception("Disallowed 'index' content name in {$this->file}.");
+        }
+
+        if (isset($this->content[$name])) {
+            throw new Exception("Content name '{$name}' already set in {$this->file}.");
+        }
+
+        $this->content[$name] = $this->fixPath($origin);
     }
 
     protected function fixPath($path)

--- a/tests/BookFixture.php
+++ b/tests/BookFixture.php
@@ -10,9 +10,9 @@ class BookFixture
     public $rootConfigFile = '/path/to/bookdown.json';
     public $rootConfigData = '{
         "title": "Example Book",
-        "content": {
-            "chapter": "chapter/bookdown.json"
-        },
+        "content": [
+            {"chapter": "chapter/bookdown.json"}
+        ],
         "target": "/_site",
         "templates": {
             "foo": "/foo.php"
@@ -24,9 +24,9 @@ class BookFixture
     public $indexConfigFile = '/path/to/chapter/bookdown.json';
     public $indexConfigData = '{
         "title": "Chapter",
-        "content": {
-            "section": "section.md"
-        }
+        "content": [
+            {"section": "section.md"}
+        ]
     }';
     public $indexConfig;
     public $indexPage;

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -11,11 +11,11 @@ class ConfigFactoryTest extends \PHPUnit_Framework_TestCase
 
     protected $data = '{
         "title": "Example Title",
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        },
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ],
         "target": "/_site"
     }';
 

--- a/tests/Config/IndexConfigTest.php
+++ b/tests/Config/IndexConfigTest.php
@@ -1,48 +1,48 @@
 <?php
 namespace Bookdown\Bookdown\Config;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class IndexConfigTest extends \PHPUnit_Framework_TestCase
 {
     protected $config;
 
     protected $validLocalJson = '{
         "title": "Example Title",
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        }
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ]
     }';
 
     protected $validRemoteJson = '{
         "title": "Example Title",
-        "content": {
-            "zim": "zim.md",
-            "dib": "dib.md",
-            "gir": "http://example.com/gir.md"
-        }
+        "content": [
+            {"zim": "zim.md"},
+            {"dib": "dib.md"},
+            {"gir": "http://example.com/gir.md"}
+        ]
     }';
 
     protected $malformedJson = '{';
 
     protected $jsonMissingTitle = '{
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        }
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ]
     }';
 
     protected $jsonMissingContent = '{
         "title": "Example Title",
-        "content" : {}
+        "content" : []
     }';
 
     protected $jsonContentIndex = '{
         "title": "Example Title",
-        "content" : {
-            "index": "index.md"
-        }
+        "content" : [
+            {"index": "index.md"}
+        ]
     }';
 
     protected function newIndexConfig($file, $data)
@@ -81,7 +81,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             'Bookdown\Bookdown\Exception',
-            "Disallowed 'index' content in /path/to/bookdown.json."
+            "Disallowed 'index' content name in /path/to/bookdown.json."
         );
         $config = $this->newIndexConfig('/path/to/bookdown.json', $this->jsonContentIndex);
     }

--- a/tests/Config/IndexConfigTest.php
+++ b/tests/Config/IndexConfigTest.php
@@ -50,6 +50,13 @@ class IndexConfigTest extends \PHPUnit_Framework_TestCase
         "content": "not an array"
     }';
 
+    protected $jsonContentItemNotStringOrObject = '{
+        "title": "Example Title",
+        "content": [
+            ["neither string", "nor object"]
+        ]
+    }';
+
     protected $jsonContentConvenience = '{
         "title": "Example Title",
         "content": [
@@ -107,6 +114,15 @@ class IndexConfigTest extends \PHPUnit_Framework_TestCase
             "Content must be an array in '/path/to/bookdown.json'."
         );
         $config = $this->newIndexConfig('/path/to/bookdown.json', $this->jsonContentNotArray);
+    }
+
+    public function testContentItemNotStringOrObject()
+    {
+        $this->setExpectedException(
+            'Bookdown\Bookdown\Exception',
+            "Content origin must be object or string in '/path/to/bookdown.json'."
+        );
+        $config = $this->newIndexConfig('/path/to/bookdown.json', $this->jsonContentItemNotStringOrObject);
     }
 
     public function testContentIndex()

--- a/tests/Config/RootConfigTest.php
+++ b/tests/Config/RootConfigTest.php
@@ -7,11 +7,11 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
 
     protected $maxRootJson = '{
         "title": "Example Title",
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        },
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ],
         "target": "my/target",
         "template": "../templates/master.php",
         "conversionProcess": "My\\\\Conversion\\\\Builder",
@@ -23,21 +23,21 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
 
     protected $minRootJson = '{
         "title": "Example Title",
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        },
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ],
         "target": "_site"
     }';
 
     protected $missingTargetJson = '{
         "title": "Example Title",
-        "content": {
-            "foo": "foo.md",
-            "bar": "/bar.md",
-            "baz": "http://example.com/baz.md"
-        }
+        "content": [
+            {"foo": "foo.md"},
+            {"bar": "/bar.md"},
+            {"baz": "http://example.com/baz.md"}
+        ]
     }';
 
     protected function newRootConfig($file, $data)

--- a/tests/Service/ProcessorBuilderTest.php
+++ b/tests/Service/ProcessorBuilderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Bookdown\Bookdown;
+namespace Bookdown\Bookdown\Service;
 
 use Bookdown\Bookdown\BookFixture;
 use Bookdown\Bookdown\Config\RootConfig;
@@ -20,9 +20,9 @@ class ProcessorBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $rootConfig = new RootConfig('/path/to/bookdown.json', '{
             "title": "Example Book",
-            "content": {
-                "foo": "foo.md"
-            },
+            "content": [
+                {"foo": "foo.md"}
+            ],
             "target": "_site/"
         }');
 
@@ -36,9 +36,9 @@ class ProcessorBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $rootConfig = new RootConfig('/path/to/bookdown.json', '{
             "title": "Example Book",
-            "content": {
-                "foo": "foo.md"
-            },
+            "content": [
+                {"foo": "foo.md"}
+            ],
             "target": "_site/",
             "tocProcess": "Bookdown\\\\Bookdown\\\\Process\\\\Fake\\\\FakeProcessUnimplementedBuilder"
         }');

--- a/tests/Service/ProcessorTest.php
+++ b/tests/Service/ProcessorTest.php
@@ -38,17 +38,17 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $this->fsio->put('/path/to/bookdown.json', '{
             "title": "Example Book",
-            "content": {
-                "chapter-1": "chapter-1/bookdown.json"
-            },
+            "content": [
+                {"chapter-1": "chapter-1/bookdown.json"}
+            ],
             "target": "/_site"
         }');
 
         $this->fsio->put('/path/to/chapter-1/bookdown.json', '{
             "title": "Chapter 1",
-            "content": {
-                "section-1": "section-1.md"
-            }
+            "content": [
+                {"section-1": "section-1.md"}
+            ]
         }');
     }
 


### PR DESCRIPTION
Change to `bookdown.json` schema.

Change to `bookdown.json` schema.

With this PR, the `"content"` element changes from an object to an array. The array elements are themselves objects in the format `{"name": "origin"}`. For example:

```
{
    "title": "My Book",
    "content": [
        {"page1": "page1.md"},
        {"page2": "whatever.md"},
        {"section1": "section1/bookdown.md"},
        {"section2": "http://example.com/remote/bookdown.json"}
    ]
}
```

This PR also allows any `"content"` array element to be an origin string instead of an object `{"name": "origin"}`. This will cause Bookdown to auto-determine the `"name"` from the origin string:
- If the origin string ends in `bookdown.json`, the `"name"` is `basename(dirname($origin))`
- Otherwise, the `"name"` is `basename($origin)`, minus any filename extension on the origin

The following is equivalent to the above:

```
{
    "title": "My Book",
    "content": [
        "page1.md",
        {"page2": "whatever.md"},
        "section1/bookdown.json",
        {"section2": "http://example.com/remote/bookdown.json"}
    ]
}
```
