### PR TITLE
Add utf8 meta in template header

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -1,5 +1,6 @@
 <head>
     <title><?php echo $this->page->getTitle(); ?></title>
+    <meta charset="UTF-8">
     <style>
         nav table {
             width: 100%;

--- a/tests/Process/RenderingProcessTest.php
+++ b/tests/Process/RenderingProcessTest.php
@@ -59,6 +59,7 @@ class RenderingProcessTest extends \PHPUnit_Framework_TestCase
         $expect = '<html>
 <head>
     <title>Chapter</title>
+    <meta charset="UTF-8">
     <style>
         nav table {
             width: 100%;


### PR DESCRIPTION
Without the charset, accents are badly encoded.
