### PR TITLE
added rootHref as command line argument

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -39,7 +39,8 @@ class Command
     {
         $getopt = $this->context->getopt(array(
             'template:',
-            'target:'
+            'target:',
+            'root-href:'
         ));
 
         if ($getopt->hasErrors()) {

--- a/src/Config/RootConfig.php
+++ b/src/Config/RootConfig.php
@@ -38,6 +38,11 @@ class RootConfig extends IndexConfig
             $this->target = rtrim($val, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             return;
         }
+
+        if ($key === 'root-href') {
+            $this->rootHref = $val;
+            return;
+        }
     }
 
     protected function init()

--- a/tests/Config/RootConfigTest.php
+++ b/tests/Config/RootConfigTest.php
@@ -18,7 +18,8 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
         "headingsProcess": "My\\\\Headings\\\\Builder",
         "tocProcess": "My\\\\Toc\\\\Builder",
         "renderingProcess": "My\\\\Rendering\\\\Builder",
-        "extra": "whatever"
+        "extra": "whatever",
+        "rootHref": "http://awesome.io/docs/"
     }';
 
     protected $minRootJson = '{
@@ -58,6 +59,7 @@ class RootConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('My\\Rendering\\Builder', $config->getRenderingProcess());
         $this->assertSame('whatever', $config->get('extra'));
         $this->assertSame('none', $config->get('no-such-key', 'none'));
+        $this->assertSame('http://awesome.io/docs/', $config->getRootHref());
     }
 
     protected function assertBasics($config)


### PR DESCRIPTION
I've added the `rootHref` as a command line argument. This allows to generate the documentation for a website with folders without defining it in the `bookdown.json` file. The local user don't need this.

_Purpose_
Generating documentation for [http://sandrokeil.github.io/interop-config/](http://sandrokeil.github.io/interop-config/) without changing the bookdown.json file of the repository.
