### PR TITLE
added markdown table support by using webuni/commonmark-table-extension

### DIFF
--- a/src/Config/RootConfig.php
+++ b/src/Config/RootConfig.php
@@ -14,6 +14,11 @@ class RootConfig extends IndexConfig
     protected $template;
     protected $rootHref;
 
+    /**
+     * @var array
+     */
+    protected $commonMarkExtensions = array();
+
     public function setOverrides(array $overrides)
     {
         foreach ($overrides as $key => $val) {
@@ -51,6 +56,7 @@ class RootConfig extends IndexConfig
         parent::init();
         $this->initTarget();
         $this->initRootHref();
+        $this->initCommonMarkExtensions();
         $this->initTemplate();
         $this->initConversionProcess();
         $this->initHeadingsProcess();
@@ -75,6 +81,25 @@ class RootConfig extends IndexConfig
         $this->rootHref = empty($this->json->rootHref)
             ? '/'
             : $this->json->rootHref;
+    }
+
+    protected function initCommonMarkExtensions()
+    {
+        if (empty($this->json->extensions)
+            || empty($this->json->extensions->commonmark)
+        ) {
+            return;
+        }
+
+        if (!is_array($this->json->extensions->commonmark)) {
+            throw new \InvalidArgumentException(
+                sprintf('The extension parameter "commonmark" must be of type "array".')
+            );
+        }
+
+        foreach ($this->json->extensions->commonmark as $extension) {
+            $this->commonMarkExtensions[] = $extension;
+        }
     }
 
     protected function initTemplate()
@@ -165,5 +190,13 @@ class RootConfig extends IndexConfig
             return $this->json->$key;
         }
         return $alt;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCommonMarkExtensions()
+    {
+        return $this->commonMarkExtensions;
     }
 }

--- a/src/Process/Conversion/ConversionProcess.php
+++ b/src/Process/Conversion/ConversionProcess.php
@@ -6,7 +6,7 @@ use Bookdown\Bookdown\Content\Page;
 use Bookdown\Bookdown\Exception;
 use Bookdown\Bookdown\Fsio;
 use Bookdown\Bookdown\Process\ProcessInterface;
-use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Converter;
 
 class ConversionProcess implements ProcessInterface
 {
@@ -18,7 +18,7 @@ class ConversionProcess implements ProcessInterface
     public function __construct(
         LoggerInterface $logger,
         Fsio $fsio,
-        CommonMarkConverter $commonMarkConverter
+        Converter $commonMarkConverter
     ) {
         $this->logger = $logger;
         $this->fsio = $fsio;

--- a/src/Process/Conversion/ConversionProcessBuilder.php
+++ b/src/Process/Conversion/ConversionProcessBuilder.php
@@ -1,10 +1,12 @@
 <?php
 namespace Bookdown\Bookdown\Process\Conversion;
 
+use League\CommonMark\DocParser;
+use League\CommonMark\Environment;
+use League\CommonMark\HtmlRenderer;
 use Psr\Log\LoggerInterface;
 use Bookdown\Bookdown\Config\RootConfig;
 use Bookdown\Bookdown\Fsio;
-use League\CommonMark\CommonMarkConverter;
 use Bookdown\Bookdown\Process\ProcessBuilderInterface;
 
 class ConversionProcessBuilder implements ProcessBuilderInterface
@@ -20,6 +22,17 @@ class ConversionProcessBuilder implements ProcessBuilderInterface
 
     protected function newCommonMarkConverter(RootConfig $config)
     {
-        return new CommonMarkConverter();
+        $environment = Environment::createCommonMarkEnvironment();
+
+        foreach ($config->getCommonMarkExtensions() as $extension) {
+            if (!class_exists($extension)) {
+                throw new \RuntimeException(
+                    'CommonMark extension class "%s" does not exists. You must use a FCQN!'
+                );
+            }
+            $environment->addExtension(new $extension());
+        }
+
+        return new \League\CommonMark\Converter(new DocParser($environment), new HtmlRenderer($environment));
     }
 }


### PR DESCRIPTION
I think Markdown table support is a nice feature. I need it for an other project.

If this is not part of the bookdown core, what do you think about a configuration entry in the `bookdown.json` to configure extensions?

Here is an example:

``` json
{
  "extension": [
    "Webuni\\CommonMark\\TableExtension\\TableExtension"
  ]
}
```
