### PR TITLE
[WIP] add navigation menu process

### DIFF
--- a/src/Config/RootConfig.php
+++ b/src/Config/RootConfig.php
@@ -14,6 +14,7 @@ class RootConfig extends IndexConfig
     protected $template;
     protected $rootHref;
     protected $tocDepth;
+    protected $menuProcess;
 
     /**
      * @var array
@@ -64,6 +65,7 @@ class RootConfig extends IndexConfig
         $this->initHeadingsProcess();
         $this->initCopyImageProcess();
         $this->initTocProcess();
+        $this->initMenuProcess();
         $this->initRenderingProcess();
     }
 
@@ -146,6 +148,13 @@ class RootConfig extends IndexConfig
             : $this->json->tocProcess;
     }
 
+    protected function initMenuProcess()
+    {
+        $this->menuProcess = empty($this->json->menuProcess)
+            ? 'Bookdown\Bookdown\Process\Navigation\MenuProcessBuilder'
+            : $this->json->menuProcess;
+    }
+
     protected function initRenderingProcess()
     {
         $this->renderingProcess = empty($this->json->renderingProcess)
@@ -171,6 +180,11 @@ class RootConfig extends IndexConfig
     public function getTocProcess()
     {
         return $this->tocProcess;
+    }
+
+    public function getMenuProcess()
+    {
+        return $this->menuProcess;
     }
 
     public function getRenderingProcess()

--- a/src/Content/Page.php
+++ b/src/Content/Page.php
@@ -13,6 +13,7 @@ class Page
     protected $next;
     protected $title;
     protected $headings = array();
+    protected $menuEntries = array();
 
     public function __construct(
         $origin,
@@ -150,5 +151,21 @@ class Page
             $page = $page->getParent();
         }
         return $page;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMenuEntries()
+    {
+        return $this->menuEntries;
+    }
+
+    /**
+     * @param array $menuEntries
+     */
+    public function setMenuEntries($menuEntries)
+    {
+        $this->menuEntries = $menuEntries;
     }
 }

--- a/src/Process/Navigation/MenuProcess.php
+++ b/src/Process/Navigation/MenuProcess.php
@@ -1,0 +1,66 @@
+<?php
+namespace Bookdown\Bookdown\Process\Navigation;
+
+use Bookdown\Bookdown\Config\RootConfig;
+use Psr\Log\LoggerInterface;
+use Bookdown\Bookdown\Content\Page;
+use Bookdown\Bookdown\Fsio;
+use Bookdown\Bookdown\Process\ProcessInterface;
+
+class MenuProcess implements ProcessInterface
+{
+    /**
+     * @var RootConfig
+     */
+    protected $config;
+
+    /**
+     * @var Fsio
+     */
+    protected $fsio;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Menu entries
+     *
+     * @var []
+     */
+    protected $menuEntries = [];
+
+    /**
+     * Process already executed
+     *
+     * @var bool
+     */
+    protected $processExecuted = false;
+
+    public function __construct(
+        LoggerInterface $logger,
+        Fsio $fsio,
+        RootConfig $config
+    ) {
+        $this->logger = $logger;
+        $this->fsio = $fsio;
+        $this->config = $config;
+    }
+
+    public function __invoke(Page $root)
+    {
+        if (true === $this->processExecuted) {
+            $root->setMenuEntries($this->menuEntries);
+            return;
+        }
+        $page = $root;
+
+        while ($page) {
+            $this->menuEntries[] = $page;
+            $page = $page->getNext();
+        }
+        $root->setMenuEntries($this->menuEntries);
+        $this->processExecuted = true;
+    }
+}

--- a/src/Process/Navigation/MenuProcessBuilder.php
+++ b/src/Process/Navigation/MenuProcessBuilder.php
@@ -1,0 +1,19 @@
+<?php
+namespace Bookdown\Bookdown\Process\Navigation;
+
+use Psr\Log\LoggerInterface;
+use Bookdown\Bookdown\Config\RootConfig;
+use Bookdown\Bookdown\Fsio;
+use Bookdown\Bookdown\Process\ProcessBuilderInterface;
+
+class MenuProcessBuilder implements ProcessBuilderInterface
+{
+    public function newInstance(RootConfig $config, LoggerInterface $logger, Fsio $fsio)
+    {
+        return new MenuProcess(
+            $logger,
+            $fsio,
+            $config
+        );
+    }
+}

--- a/src/Service/ProcessorBuilder.php
+++ b/src/Service/ProcessorBuilder.php
@@ -26,6 +26,7 @@ class ProcessorBuilder
                 $this->newProcess($config, 'Headings'),
                 $this->newProcess($config, 'CopyImage'),
                 $this->newProcess($config, 'Toc'),
+                $this->newProcess($config, 'Menu'),
                 $this->newProcess($config, 'Rendering'),
             )
         );


### PR DESCRIPTION
@pmjones This is a WIP for a navigation menu. Idea is simple. Save all pages to every page and build the menu in a template depending on page type. IndexPage and RootPage is a menu entry, Page is a sub entry of them.

> I've to add support for multiple depths.

I'm not sure if we should provide a default menu template or give only an example in the docs like this one?

``` php
$page = $this->page;
$isSubMenu = false;
echo '<ul>';
foreach ($page->getMenuEntries() as $entry) {
    if ($entry instanceof \Bookdown\Bookdown\Content\RootPage) {
        echo '<li>';
        echo $this->anchorRaw($entry->getHref(), $entry->getTitle());
        echo '</li>';
        continue;
    }
    if ($entry instanceof \Bookdown\Bookdown\Content\IndexPage) {
        if ($isSubMenu) {
            echo '</ul>';
        }
        $isSubMenu = true;
        echo '<li>';
        echo $this->anchorRaw($entry->getHref(), $entry->getTitle());
        echo '<ul>';
        continue;
    }
    echo '<li>';
    echo $this->anchorRaw($entry->getHref(), $entry->getTitle());
    echo '</li>';
}
if ($isSubMenu) {
    echo '</ul></li>';
}
echo '</ul>';
```

You will get something like this.

``` html
<ul>
    <li><a href="/">proophessor - Exploring prooph components</a></li>
    <li><a href="/proophessor/">Exploring prooph components</a>
        <ul>
            <li><a href="/proophessor/prooph-in-a-nutshell.html">prooph in a nutshell</a></li>
            <li><a href="/proophessor/components.html">prooph components</a></li>
            <li><a href="/proophessor/wishlist.html">Component Wishlist</a></li>
        </ul>
    <li><a href="/snapshotter/">Snapshot tool for the prooph event-store</a>
        <ul>
            <li><a href="/snapshotter/intro.html">snapshotter</a></li>
            <li><a href="/snapshotter/configuration.html">Configuration</a></li>
        </ul>
    </li>
</ul>
```
