### PR TITLE
Add valid heading id attribute

### DIFF
--- a/src/Content/Heading.php
+++ b/src/Content/Heading.php
@@ -41,9 +41,28 @@ class Heading
     {
         $href = $this->href;
         if ($this->id) {
-            $href .= '#' . $this->id;
+            $href .= $this->getHrefAnchor();
         }
         return $href;
+    }
+
+    /**
+     * Creates a complete anchor href attribute for links.
+     *
+     * @return string
+     */
+    public function getHrefAnchor(){
+        return '#' . $this->getAnchor();
+    }
+
+    /**
+     * Return a valid anchor string tag to use as html id attribute.
+     *
+     * @return string
+     */
+    public function getAnchor()
+    {
+        return str_replace('.', '-', $this->getId());
     }
 
     public function getLevel()

--- a/src/Content/Heading.php
+++ b/src/Content/Heading.php
@@ -51,8 +51,14 @@ class Heading
      *
      * @return string
      */
-    public function getHrefAnchor(){
-        return '#' . $this->getAnchor();
+    public function getHrefAnchor()
+    {
+        $hrefAnchor = null;
+
+        if ($this->id) {
+            return '#' . $this->getAnchor();
+        }
+        return $hrefAnchor;
     }
 
     /**
@@ -62,7 +68,12 @@ class Heading
      */
     public function getAnchor()
     {
-        return str_replace('.', '-', $this->getId());
+        $anchor = null;
+
+        if ($this->id) {
+            $anchor = str_replace('.', '-', $this->getId());
+        }
+        return $anchor;
     }
 
     public function getLevel()

--- a/src/Process/Headings/HeadingsProcess.php
+++ b/src/Process/Headings/HeadingsProcess.php
@@ -136,7 +136,7 @@ class HeadingsProcess implements ProcessInterface
         $number->nodeValue = $heading->getNumber() . ' ';
         $node->insertBefore($number, $node->firstChild);
 
-        $node->setAttribute('id', $heading->getId());
+        $node->setAttribute('id', $heading->getAnchor());
     }
 
     protected function newHeading(DomNode $node)

--- a/tests/Content/HeadingTest.php
+++ b/tests/Content/HeadingTest.php
@@ -3,6 +3,9 @@ namespace Bookdown\Bookdown\Content;
 
 class HeadingTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var HeadingFactory
+     */
     protected $headingFactory;
 
     protected function setUp()
@@ -12,6 +15,7 @@ class HeadingTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadingWithId()
     {
+        /* @var Heading $heading */
         $heading = $this->headingFactory->newInstance(
             '1.2.3.',
             'Example Heading',
@@ -23,11 +27,14 @@ class HeadingTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($heading->getTitle(), 'Example Heading');
         $this->assertSame($heading->getId(), '1.2.3');
         $this->assertSame($heading->getLevel(), 3);
-        $this->assertSame($heading->getHref(), '/foo/bar/baz#1.2.3');
+        $this->assertSame($heading->getHref(), '/foo/bar/baz#1-2-3');
+        $this->assertSame($heading->getHrefAnchor(), '#1-2-3');
+        $this->assertSame($heading->getAnchor(), '1-2-3');
     }
 
     public function testHeadingWithoutId()
     {
+        /* @var Heading $heading */
         $heading = $this->headingFactory->newInstance(
             '1.2.3.',
             'Example Heading',
@@ -39,5 +46,7 @@ class HeadingTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($heading->getId(), null);
         $this->assertSame($heading->getLevel(), 3);
         $this->assertSame($heading->getHref(), '/foo/bar/baz');
+        $this->assertSame($heading->getHrefAnchor(), null);
+        $this->assertSame($heading->getAnchor(), null);
     }
 }

--- a/tests/Process/RenderingProcessTest.php
+++ b/tests/Process/RenderingProcessTest.php
@@ -131,13 +131,13 @@ class RenderingProcessTest extends \PHPUnit_Framework_TestCase
 
 <h1>1. Chapter</h1>
 <dl>
-<dt>1.1. <a href="/chapter/section.html#1.1">Title</a></dt>
+<dt>1.1. <a href="/chapter/section.html#1-1">Title</a></dt>
 <dd><dl>
-<dt>1.1.1. <a href="/chapter/section.html#1.1.1">Subtitle <code>code</code> A</a></dt>
+<dt>1.1.1. <a href="/chapter/section.html#1-1-1">Subtitle <code>code</code> A</a></dt>
 <dd><dl>
-<dt>1.1.1.1. <a href="/chapter/section.html#1.1.1.1">Sub-subtitle</a></dt>
+<dt>1.1.1.1. <a href="/chapter/section.html#1-1-1-1">Sub-subtitle</a></dt>
 </dl></dd>
-<dt>1.1.2. <a href="/chapter/section.html#1.1.2">Subtitle B</a></dt>
+<dt>1.1.2. <a href="/chapter/section.html#1-1-2">Subtitle B</a></dt>
 </dl></dd>
 </dl>
 


### PR DESCRIPTION
To ensure that the h[1-6] html id attribute works as anchor compatible with javascript and css it is recommended to remove the period (.) from the id attribute. 
