### PR TITLE
Do not stop build process if some images are missing

### DIFF
--- a/src/Process/Resource/CopyImageProcess.php
+++ b/src/Process/Resource/CopyImageProcess.php
@@ -135,7 +135,12 @@ class CopyImageProcess implements ProcessInterface
         if (!$this->fsio->isDir($dir)) {
             $this->fsio->mkdir($dir);
         }
-        $this->fsio->put($file, $this->fsio->get($originFile));
+
+        if (file_exists($originFile)) {
+            $this->fsio->put($file, $this->fsio->get($originFile));
+        } else {
+            $this->logger->warning("      Images {$originFile} does not exists.");
+        }
         return $this->config->getRootHref() . (str_replace($this->config->getTarget(), '', $dir)) . $imageName;
     }
 

--- a/src/Process/Resource/CopyImageProcess.php
+++ b/src/Process/Resource/CopyImageProcess.php
@@ -139,7 +139,7 @@ class CopyImageProcess implements ProcessInterface
         if (file_exists($originFile)) {
             $this->fsio->put($file, $this->fsio->get($originFile));
         } else {
-            $this->logger->warning("      Images {$originFile} does not exists.");
+            $this->logger->warning("      Image {$originFile} does not exist.");
         }
         return $this->config->getRootHref() . (str_replace($this->config->getTarget(), '', $dir)) . $imageName;
     }

--- a/src/Process/Resource/CopyImageProcess.php
+++ b/src/Process/Resource/CopyImageProcess.php
@@ -136,9 +136,9 @@ class CopyImageProcess implements ProcessInterface
             $this->fsio->mkdir($dir);
         }
 
-        if (file_exists($originFile)) {
+        try {
             $this->fsio->put($file, $this->fsio->get($originFile));
-        } else {
+        } catch (\Exception $e) {
             $this->logger->warning("      Image {$originFile} does not exist.");
         }
         return $this->config->getRootHref() . (str_replace($this->config->getTarget(), '', $dir)) . $imageName;


### PR DESCRIPTION
I've recently try to genereate [kanboard](https://github.com/kanboard/website) french documentation, and discover that some images are missing. 

Full generation was stop at first image missing. E.g: 

```
    Processing copy images for doc\fr_FR\html\index.html
    Processing copy images for doc\fr_FR\html\screenshots.html
file_get_contents(doc\fr_FR/screenshots/dropdown-screenshot.png): failed to open stream: No such file or directory
```

I'd like to have rather a warning message and continue to build all doc. Something like that 

```
  Applying Bookdown\Bookdown\Process\Resource\CopyImageProcess
    Processing copy images for doc\fr_FR\html\index.html
    Processing copy images for doc\fr_FR\html\screenshots.html
      Images doc\fr_FR/screenshots/dropdown-screenshot.png does not exists.
      Images doc\fr_FR/screenshots/task-screenshot.png does not exists.
```
