### PR TITLE
Add test case for same name

### DIFF
--- a/tests/Config/IndexConfigTest.php
+++ b/tests/Config/IndexConfigTest.php
@@ -67,6 +67,14 @@ class IndexConfigTest extends \PHPUnit_Framework_TestCase
         ]
     }';
 
+    protected $jsonContentSameResolvedName = '{
+        "title": "Example Title",
+        "content": [
+            "http://test1.example.dom/master/bookdown.json",
+            "http://test2.example.dom/master/bookdown.json"
+        ]
+    }';
+
     protected $jsonReusedContentName = '{
         "title": "Example Title",
         "content": [
@@ -133,6 +141,16 @@ class IndexConfigTest extends \PHPUnit_Framework_TestCase
         );
         $config = $this->newIndexConfig('/path/to/bookdown.json', $this->jsonContentIndex);
     }
+
+    public function testDuplicateName()
+    {
+        $this->setExpectedException(
+            'Bookdown\Bookdown\Exception',
+            "Content name 'master' already set in '/path/to/bookdown.json'."
+        );
+        $config = $this->newIndexConfig('/path/to/bookdown.json', $this->jsonContentSameResolvedName);
+    }
+
 
     public function testValidLocal()
     {


### PR DESCRIPTION
If the urls are for example
 - test1.github.com/master/bookdown.json
 - test2.github.com/master/bookdown.json

The config uses master as name which throws an exception. This can be avoided by using a custom name inside the bookdown.json!

This unittest should document this behaviour and should help fixing it in case it's a bug.