### PR TITLE
replace Monolog with Stdlog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "aura/html": "~2.0",
         "aura/view": "~2.0",
         "league/commonmark": "~0.7",
-        "monolog/monolog": "~1.0"
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "webuni/commonmark-table-extension": "^0.4.2",

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,9 +2,6 @@
 namespace Bookdown\Bookdown;
 
 use Aura\Cli\CliFactory;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Monolog\Formatter\LineFormatter;
 
 class Container
 {
@@ -16,8 +13,8 @@ class Container
     protected $fsio;
 
     public function __construct(
-        $stdout = 'php://stdout',
-        $stderr = 'php://stderr',
+        $stdout = STDOUT,
+        $stderr = STDERR,
         $fsioClass = 'Bookdown\Bookdown\Fsio'
     ) {
         $this->stdout = $stdout;
@@ -77,15 +74,7 @@ class Container
     public function getLogger()
     {
         if (! $this->logger) {
-            $formatter = new LineFormatter('%message%' . PHP_EOL);
-
-            $stderr = new StreamHandler($this->stderr, Logger::ERROR, false);
-            $stderr->setFormatter($formatter);
-
-            $stdout = new StreamHandler($this->stdout, Logger::DEBUG, false);
-            $stdout->setFormatter($formatter);
-
-            $this->logger = new Logger('Bookdown', array($stderr, $stdout));
+            $this->logger = new Stdlog($this->stdout, $this->stderr);
         }
 
         return $this->logger;

--- a/src/Stdlog.php
+++ b/src/Stdlog.php
@@ -1,0 +1,84 @@
+<?php
+namespace Bookdown\Bookdown;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+class Stdlog extends AbstractLogger
+{
+    /**
+     *
+     * The stdout file handle.
+     *
+     * @var resource
+     *
+     */
+    protected $stdout;
+
+    /**
+     *
+     * The stderr file handle.
+     *
+     * @var resource
+     *
+     */
+    protected $stderr;
+
+    /**
+     *
+     * Write to stderr for these log levels.
+     *
+     * @var array
+     *
+     */
+    protected $stderrLevels = [
+        LogLevel::EMERGENCY,
+        LogLevel::ALERT,
+        LogLevel::CRITICAL,
+        LogLevel::ERROR,
+    ];
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param resource $stdout Write to stdout on this handle.
+     *
+     * @param resource $stderr Write to stderr on this handle.
+     *
+     */
+    public function __construct($stdout, $stderr)
+    {
+        $this->stdout = $stdout;
+        $this->stderr = $stderr;
+    }
+
+    /**
+     *
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     *
+     * @param string $message
+     *
+     * @param array $context
+     *
+     * @return null
+     *
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $replace = [];
+        foreach ($context as $key => $val) {
+            $replace['{' . $key . '}'] = $val;
+        }
+        $message = strtr($message, $replace) . PHP_EOL;
+
+        $handle = $this->stdout;
+        if (in_array($level, $this->stderrLevels)) {
+            $handle = $this->stderr;
+        }
+
+        fwrite($handle, $message);
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -47,7 +47,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testGetLogger()
     {
         $logger = $this->container->getLogger();
-        $this->assertInstanceOf('Monolog\Logger', $logger);
+        $this->assertInstanceOf('Psr\Log\LoggerInterface', $logger);
         $again = $this->container->getLogger();
         $this->assertSame($logger, $again);
     }

--- a/tests/Process/ConversionProcessTest.php
+++ b/tests/Process/ConversionProcessTest.php
@@ -13,8 +13,8 @@ class ConversionProcessTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
         $this->fsio = $container->getFsio();

--- a/tests/Process/CopyImageProcessTest.php
+++ b/tests/Process/CopyImageProcessTest.php
@@ -20,8 +20,8 @@ class CopyImageProcessTest extends \PHPUnit_Framework_TestCase
     private function initializeBook($fixtureClass)
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
         $this->fsio = $container->getFsio();

--- a/tests/Process/HeadingsProcessTest.php
+++ b/tests/Process/HeadingsProcessTest.php
@@ -16,8 +16,8 @@ class HeadingsProcessTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
         $this->fsio = $container->getFsio();

--- a/tests/Process/IndexProcessTest.php
+++ b/tests/Process/IndexProcessTest.php
@@ -27,8 +27,8 @@ class IndexProcessTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
 

--- a/tests/Process/RenderingProcessTest.php
+++ b/tests/Process/RenderingProcessTest.php
@@ -13,8 +13,8 @@ class RenderingProcessTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
         $this->fsio = $container->getFsio();

--- a/tests/Service/CollectorTest.php
+++ b/tests/Service/CollectorTest.php
@@ -15,8 +15,8 @@ class CollectorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
 

--- a/tests/Service/ProcessorTest.php
+++ b/tests/Service/ProcessorTest.php
@@ -15,8 +15,8 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $container = new Container(
-            'php://memory',
-            'php://memory',
+            fopen('php://memory', 'w+'),
+            fopen('php://memory', 'w+'),
             'Bookdown\Bookdown\FakeFsio'
         );
 


### PR DESCRIPTION
Instead of installing Monolog (rather heavy for our purposes) this PR implements a minimal stdout/stderr PSR-3 logger.

@sandrokeil et al.: any strong feelings for or against this?