### PR TITLE
Decouple href anchor from existence of id property

### DIFF
--- a/src/Content/Heading.php
+++ b/src/Content/Heading.php
@@ -130,8 +130,10 @@ class Heading
     public function getHref()
     {
         $href = $this->href;
-        if ($this->id) {
-            $href .= $this->getHrefAnchor();
+        $hrefAnchor = $this->getHrefAnchor();
+
+        if (null !== $this->getId() && null !== $hrefAnchor) {
+            $href .= $hrefAnchor;
         }
         return $href;
     }
@@ -140,14 +142,14 @@ class Heading
      *
      * Creates a complete anchor href attribute for links.
      *
-     * @return string
+     * @return string|null
      *
      */
     public function getHrefAnchor()
     {
-        $hrefAnchor = null;
+        $hrefAnchor = $this->getAnchor();
 
-        if ($this->id) {
+        if (null !== $hrefAnchor) {
             return '#' . $this->getAnchor();
         }
         return $hrefAnchor;
@@ -157,15 +159,15 @@ class Heading
      *
      * Return a valid anchor string tag to use as html id attribute.
      *
-     * @return string
+     * @return string|null
      *
      */
     public function getAnchor()
     {
         $anchor = null;
 
-        if ($this->id) {
-            $anchor = str_replace('.', '-', $this->getId());
+        if (null !== $this->getNumber()) {
+            $anchor = str_replace('.', '-', trim($this->getNumber(), '.'));
         }
         return $anchor;
     }

--- a/tests/Content/HeadingTest.php
+++ b/tests/Content/HeadingTest.php
@@ -41,7 +41,7 @@ class HeadingTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($heading->getId(), null);
         $this->assertSame($heading->getLevel(), 3);
         $this->assertSame($heading->getHref(), '/foo/bar/baz');
-        $this->assertSame($heading->getHrefAnchor(), null);
-        $this->assertSame($heading->getAnchor(), null);
+        $this->assertSame($heading->getHrefAnchor(), '#1-2-3');
+        $this->assertSame($heading->getAnchor(), '1-2-3');
     }
 }


### PR DESCRIPTION
If a heading had no id property the getAnchor and getHrefAnchor returned null.