### PR TITLE
in ConversionProcess, convert relative .md hrefs to .html

### DIFF
--- a/src/Process/Headings/HeadingsProcess.php
+++ b/src/Process/Headings/HeadingsProcess.php
@@ -292,7 +292,7 @@ class HeadingsProcess implements ProcessInterface
         $heading = $this->newHeading($node);
         $this->headings[] = $heading;
 
-        $number = new DOMText();
+        $number = new DomText();
 
         switch ($this->numbering) {
             case false:


### PR DESCRIPTION
This is so that .md links in non-converted markdown sources will work, and when converted to HTML by Bookdown the links will point to the rendered file.